### PR TITLE
Remove unnecessary chapter/section metadata

### DIFF
--- a/chapters/chap01.ipynb
+++ b/chapters/chap01.ipynb
@@ -61,7 +61,6 @@
     "tags": []
    },
    "source": [
-    "(chapter_programming)=\n",
     "# Programming as a way of thinking\n",
     "\n",
     "The first goal of this book is to teach you how to program in Python.\n",

--- a/chapters/chap04.ipynb
+++ b/chapters/chap04.ipynb
@@ -58,7 +58,6 @@
     "tags": []
    },
    "source": [
-    "(section_turtle_module)=\n",
     "## The jupyturtle module\n",
     "\n",
     "To use the `jupyturtle` module, we can import it like this."
@@ -247,7 +246,6 @@
     "tags": []
    },
    "source": [
-    "(section_encapsulation)=\n",
     "## Encapsulation and generalization\n",
     "\n",
     "Let's take the square-drawing code from the previous section and put it in a function called `square`."
@@ -753,7 +751,6 @@
     "tags": []
    },
    "source": [
-    "(section_docstring)=\n",
     "## Docstrings\n",
     "\n",
     "A **docstring** is a string at the beginning of a function that explains the interface (\"doc\" is short for \"documentation\").\n",

--- a/chapters/chap06.ipynb
+++ b/chapters/chap06.ipynb
@@ -525,7 +525,6 @@
     "tags": []
    },
    "source": [
-    "(section_incremental)=\n",
     "## Incremental development\n",
     "\n",
     "As you write larger functions, you might find yourself spending more\n",
@@ -1118,7 +1117,6 @@
     "tags": []
    },
    "source": [
-    "(section_fibonacci)=\n",
     "## Fibonacci\n",
     "\n",
     "After `factorial`, the most common example of a recursive function is `fibonacci`, which has the following definition: \n",
@@ -1305,7 +1303,6 @@
     "tags": []
    },
    "source": [
-    "(section_debugging_factorial)=\n",
     "## Debugging\n",
     "\n",
     "Breaking a large program into smaller functions creates natural checkpoints for debugging.\n",

--- a/chapters/chap07.ipynb
+++ b/chapters/chap07.ipynb
@@ -33,7 +33,6 @@
     "tags": []
    },
    "source": [
-    "(chapter_search)=\n",
     "# Iteration and Search\n",
     "\n",
     "In 1939 Ernest Vincent Wright published a 50,000 word novel called *Gadsby* that does not contain the letter \"e\". Since \"e\" is the most common letter in English, writing even a few words without using it is difficult.\n",

--- a/chapters/chap08.ipynb
+++ b/chapters/chap08.ipynb
@@ -615,7 +615,6 @@
     "tags": []
    },
    "source": [
-    "(section_writing_files)=\n",
     "## Writing files\n",
     "\n",
     "String operators and methods are useful for reading and writing text files.\n",

--- a/chapters/chap09.ipynb
+++ b/chapters/chap09.ipynb
@@ -1302,7 +1302,6 @@
     "tags": []
    },
    "source": [
-    "(section_word_list)=\n",
     "## Making a word list\n",
     "\n",
     "In the previous chapter, we read the file `words.txt` and searched for words with certain properties, like using the letter `e`.\n",

--- a/chapters/chap10.ipynb
+++ b/chapters/chap10.ipynb
@@ -350,7 +350,6 @@
     "tags": []
    },
    "source": [
-    "(section_dictionary_in_operator)=\n",
     "## The in operator\n",
     "\n",
     "The `in` operator works on dictionaries, too; it tells you whether something appears as a *key* in the dictionary."
@@ -905,7 +904,6 @@
     "tags": []
    },
    "source": [
-    "(section_palindrome_list)=\n",
     "## Accumulating a list\n",
     "\n",
     "For many programming tasks, it is useful to loop through one list or dictionary while building another.\n",
@@ -1033,7 +1031,6 @@
     "tags": []
    },
    "source": [
-    "(section_memos)=\n",
     "## Memos\n",
     "\n",
     "If you ran the `fibonacci` function from [Chapter 6](section_fibonacci), maybe you noticed that the bigger the argument you provide, the longer the function takes to run."

--- a/chapters/chap11.ipynb
+++ b/chapters/chap11.ipynb
@@ -33,7 +33,6 @@
     "tags": []
    },
    "source": [
-    "(chapter_tuples)=\n",
     "# Tuples\n",
     "\n",
     "This chapter introduces one more built-in type, the tuple, and then shows how lists, dictionaries, and tuples work together.\n",
@@ -742,7 +741,6 @@
     "tags": []
    },
    "source": [
-    "(section_argument_pack)=\n",
     "## Argument packing\n",
     "\n",
     "Functions can take a variable number of arguments. \n",
@@ -1395,7 +1393,6 @@
     "tags": []
    },
    "source": [
-    "(section_debugging_11)=\n",
     "## Debugging\n",
     "\n",
     "Lists, dictionaries and tuples are **data structures**.\n",
@@ -1694,7 +1691,6 @@
     "tags": []
    },
    "source": [
-    "(section_exercise_11)=\n",
     "### Exercise\n",
     "\n",
     "In this chapter we made a dictionary that maps from each letter to its index in the alphabet."

--- a/chapters/chap12.ipynb
+++ b/chapters/chap12.ipynb
@@ -665,7 +665,6 @@
     "tags": []
    },
    "source": [
-    "(section_dictionary_subtraction)=\n",
     "## Dictionary subtraction\n",
     "\n",
     "Suppose we want to spell-check a book -- that is, find a list of words that might be misspelled.\n",
@@ -1668,7 +1667,6 @@
     "tags": []
    },
    "source": [
-    "(section_debugging_12)=\n",
     "## Debugging\n",
     "\n",
     "At this point we are writing more substantial programs, and you might find that you are spending more time debugging.\n",

--- a/chapters/chap13.ipynb
+++ b/chapters/chap13.ipynb
@@ -939,7 +939,6 @@
     "tags": []
    },
    "source": [
-    "(section_storing_data_structure)=\n",
     "## Storing data structures\n",
     "\n",
     "In the previous example, the keys and values in the shelf are strings.\n",
@@ -1147,7 +1146,6 @@
     "tags": []
    },
    "source": [
-    "(section_md5_digest)=\n",
     "## Checking for equivalent files\n",
     "\n",
     "Now let's get back to the goal of this chapter: searching for different files that contain the same data.\n",
@@ -1342,7 +1340,6 @@
     "tags": []
    },
    "source": [
-    "(section_walking_directories)=\n",
     "## Walking directories\n",
     "\n",
     "The following function takes as an argument the directory we want to search.\n",

--- a/chapters/chap14.ipynb
+++ b/chapters/chap14.ipynb
@@ -1097,7 +1097,6 @@
     "tags": []
    },
    "source": [
-    "(section_debugging_14)=\n",
     "## Debugging\n",
     "\n",
     "Python provides several built-in functions that are useful for testing and debugging programs that work with objects.\n",

--- a/chapters/chap16.ipynb
+++ b/chapters/chap16.ipynb
@@ -50,7 +50,6 @@
     "tags": []
    },
    "source": [
-    "(section_create_point)=\n",
     "## Creating a Point\n",
     "\n",
     "In computer graphics a location on the screen is often represented using a pair of coordinates in an `x`-`y` plane.\n",

--- a/chapters/chap17.ipynb
+++ b/chapters/chap17.ipynb
@@ -33,7 +33,6 @@
     "tags": []
    },
    "source": [
-    "(chapter_inheritance)=\n",
     "# Inheritance\n",
     "\n",
     "The language feature most often associated with object-oriented programming is **inheritance**.\n",
@@ -808,7 +807,6 @@
     "tags": []
    },
    "source": [
-    "(section_print_deck)=\n",
     "## Printing the deck\n",
     "\n",
     "Here is a `__str__` method for `Deck`."


### PR DESCRIPTION
There are a few places that show `(chapter_x)=` or `(section_y)=` and they don't seem to have any value/meaning. This removes them.