### PR TITLE
Update chap18.ipynb

### DIFF
--- a/chapters/chap18.ipynb
+++ b/chapters/chap18.ipynb
@@ -1661,7 +1661,7 @@
    "id": "07be77f3",
    "metadata": {},
    "source": [
-    "In this example, the value of `kwargs` is printed, but otherwise is has no effect.\n",
+    "In this example, the value of `kwargs` is printed, but otherwise it has no effect.\n",
     "\n",
     "But the `**` operator can also be used in an argument list to unpack a dictionary.\n",
     "For example, here's a version of `mean` that packs any keyword arguments it gets and then unpacks them as keyword arguments for `sum`."


### PR DESCRIPTION
There is a small mistake in [18.8. Packing keyword arguments](https://allendowney.github.io/ThinkPython/chap18.html#packing-keyword-arguments).



Instead of "is", it should be "it" for correct grammar.